### PR TITLE
allow registered events to be checked from mocks

### DIFF
--- a/src/ipc-main.ts
+++ b/src/ipc-main.ts
@@ -92,7 +92,7 @@ class ipcMain implements IpcMain {
   prependOnceListener(_event: string | symbol, _listener: (...args: any[]) => void): any {}
 
   eventNames(): Array<string | symbol> {
-    return ['undefined']
+    return this.emitter.eventNames()
   }
 }
 

--- a/src/ipc-renderer.ts
+++ b/src/ipc-renderer.ts
@@ -99,7 +99,7 @@ class ipcRenderer implements IpcRenderer {
   prependOnceListener(_event: string | symbol, _listener: (...args: any[]) => void): any {}
 
   eventNames(): Array<string | symbol> {
-    return ['undefined']
+    return this.emitter.eventNames()
   }
 }
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -148,3 +148,24 @@ describe('send event from main to renderer', () => {
     })
   })
 })
+
+describe('registered event handlers are returned from #eventNames', () => {
+  let ipcMain: ipcMain
+  let ipcRenderer: ipcRenderer
+
+  beforeEach(() => {
+    const mocked = createIPCMock()
+    ipcMain = mocked.ipcMain
+    ipcRenderer = mocked.ipcRenderer
+  })
+
+  it('ipcMain should return the events that were registered', () => {
+    ipcMain.on('test-event', () => null)
+    expect(ipcMain.eventNames()).toEqual(expect.arrayContaining(['test-event']))
+  })
+
+  it('ipcRenderer should return the events that were registered', () => {
+    ipcRenderer.on('test-event', () => null)
+    expect(ipcRenderer.eventNames()).toEqual(expect.arrayContaining(['test-event']))
+  })
+})


### PR DESCRIPTION
This is useful for example to test if all expected handlers are
registered. Behavior before was just to always return an array of undefined, which isn't super useful

before:
```
  ● registered event handlers are returned from #eventNames › ipcRenderer should return the events that were registered

    expect(received).toEqual(expected) // deep equality

    Expected: ArrayContaining ["test-event"]
    Received: ["undefined"]

      167 |   it('ipcRenderer should return the events that were registered', () => {
      168 |     ipcRenderer.on('test-event', () => null)
    > 169 |     expect(ipcRenderer.eventNames()).toEqual(expect.arrayContaining(['test-event']))
          |                                      ^
      170 |   })
      171 | })
      172 |

      at Object.<anonymous> (test/integration.spec.ts:169:38)
```