### PR TITLE
Fix memory leak in invoke

### DIFF
--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -99,6 +99,15 @@ describe('send event from renderer to main', () => {
       })
       await expect(ipcRenderer.invoke('test-event', 'hoge')).rejects.toThrow(Error)
     })
+
+    it('removes event listeners it doesnt need', async () => {
+      ipcMain.handle('test-event', () => {})
+      for (let i = 0; i < 20; ++i) {
+        await ipcRenderer.invoke('test-event')
+      }
+      const event = ipcRenderer.errorEmitter.eventNames().find((n) => typeof n === 'string' && n.match(/test-event/)) as string
+      expect(ipcRenderer.errorEmitter.listenerCount(event)).toBe(0)
+    })
   })
 })
 


### PR DESCRIPTION
Fixes a memory leak in invoke. If invoke resolves, the error listener never gets removed. If invoke rejects, the success listener never gets removed.

This is the test output before the patch.
```
  ● send event from renderer to main › invoke › removes event listeners it doesnt need

    expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: 20

  expect(ipcRenderer.errorEmitter.listenerCount(event)).toBe(0)
```

I discovered this in my tests when I saw this warning:

```
(node:43082) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 __electron_mock_ipc__:globalStore:dispatch listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
```
