### PR TITLE
Restrict Claude Code review to external contributors only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Skip bot-created PRs (dependabot, renovate, etc.)
+    # Only run for external contributors (skip bots and repository owner/members)
     if: |
-      github.event.pull_request.user.type != 'Bot'
+      github.event.pull_request.user.type != 'Bot' &&
+      github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Update the workflow to only run on PRs from external contributors (forks), excluding both bot PRs and PRs from repository owner/members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)